### PR TITLE
Remove second '--' from ssh call, it not more works with OpenSSH ≥ 7.6

### DIFF
--- a/bscp
+++ b/bscp
@@ -110,7 +110,7 @@ def bscp(local_filename, remote_host, remote_filename, blocksize, hashname):
         blockcount = int((size + blocksize - 1) / blocksize)
 
         remote_command = 'python -c "%s"' % (remote_script,)
-        command = ('ssh', '--', remote_host, '--', remote_command)
+        command = ('ssh', '--', remote_host, remote_command)
         p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         io = IOCounter(p.stdout, p.stdin)
 


### PR DESCRIPTION
Closes: #10

This upstream commit causes the second `--` to be passed to the remote
shell which then bails out with a runtime error due to an unknown
commandline option:

> commit 643c2ad82910691b2240551ea8b14472f60b5078
> Author: djm@openbsd.org <djm@openbsd.org>
> Date:   Sat Aug 12 06:46:01 2017 +0000
>
>     upstream commit
>
>     make "--" before the hostname terminate command-line
>     option processing completely; previous behaviour would not prevent further
>     options appearing after the hostname (ssh has a supported options after the
>     hostname for >20 years, so that's too late to change).
>
>     ok deraadt@
>
>     Upstream-ID: ef5ee50571b98ad94dcdf8282204e877ec88ad89

This commit was included with OpenSSH ≥ 7.6, so bscp stopped working
with all versions of OpenSSH ≥ 7.6 on the client side. This especially
includes Ubuntu 18.04 LTS and all later Ubuntu releases.

Debian also backported this change to its OpenSSH versions shipped
with Debian 9 Stretch and Debian 8 Jessie in late 2017. See
https://bugs.debian.org/873201 for details.